### PR TITLE
remove interface requirement

### DIFF
--- a/THOUGHTS.md
+++ b/THOUGHTS.md
@@ -29,7 +29,6 @@
 - Header files should be suffixed with **.h** (if they do not contain code implementation)
 - Use as much **private** stuff as possible, add a ```_``` (underscore) as a suffix (at the end)
 - Make sure not to have cross-dependancies, **modularize** as much as possible
-- Each module should have a pure abstract class as an interface, **use interfaces**!
 - Each module should be in it's own **subfolder in the repository**, under the ```src``` folder (including the header files for the module)
 - Seperate control functions (function that call functions with some order and logic), seperate logic implementation functions (functions that contain code that does stuff)
 - Seperate every "single" task into a single function, **one function only does one thing**!


### PR DESCRIPTION
As the scope of the project is quite limited, we can just use class objects and their provided public functions in caller functions directly. (this is how we have it set up currently)

This doesn't mean that using an interface is not appropriate in some cases, but it would no longer be a requirement to follow in every module.