### PR TITLE
add header reply.h for numeric replies

### DIFF
--- a/src/common/reply.h
+++ b/src/common/reply.h
@@ -1,9 +1,13 @@
 #ifndef REPLY_H
 #define REPLY_H
 
-// Numeric replies in order
-#define RPL_WELCOME_001()
+// Meta definitions
+#define RPL_META_MESSAGE(servername, numeric, message) (std::string(":") + servername + " " + numeric + " " + message + "\r\n")
 
-// Other replies
+// Numeric replies in order
+#define RPL_WELCOME_001(servername, nick, user, host) (RPL_META_MESSAGE(servername, "001", "Welcome to the Internet Relay Network " + nick + "!" + user "@" + host))
+#define RPL_YOURHOST_002(servername, version) (RPL_META_MESSAGE(servername, "002", "Your host is " + servername + ", running version " + version))
+#define RPL_CREATED_003(servername, date) (RPL_META_MESSAGE(servername, "003", "This server was created " + date))
+#define RPL_MYINFO_004(servername, version, user_modes, channel_modes) (RPL_META_MESSAGE(servername, "004", servername + " " + version + " " + user_modes + " " + channel_modes))
 
 #endif

--- a/src/common/reply.h
+++ b/src/common/reply.h
@@ -1,0 +1,9 @@
+#ifndef REPLY_H
+#define REPLY_H
+
+// Numeric replies in order
+#define RPL_WELCOME_001()
+
+// Other replies
+
+#endif


### PR DESCRIPTION
Added reply.h to common headers for pre-processor macros defining numeric replies from IRC.
Added numeric replies from 001 to 004, the mandatory ones to complete a client registration successfully.

There is a bit of controversy with numeric replies, the IRCv3 spec differs from the RFC 2812.