### PR TITLE
add git-clean-branches target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,3 +81,9 @@ lldb: fclean $(NAME)
 test: $(TEST_SRCS) $(NOMAIN_SRCS)
 	$(CC) $(CFLAGS) -o test.out $(TEST_SRCS) $(NOMAIN_SRCS)
 	./test.out $(ARGS)
+
+.PHONY: git-clean-branches
+git-clean-branches:
+	git checkout main
+	git fetch -p
+	git branch --merged | grep -v "\*" | xargs -n 1 git branch -d


### PR DESCRIPTION
This Makefile target does the following:

1. Switches to the main branch
2. Fetches all changes from the remote (without making any changes locally)
3. Removes all references to non-existing branches on the remote
4. Removes all local branches that have been merged to the main branch only if:
   - The branch has been pushed and merged to the remote main branch
   - The branch has no local changes in them that are not pushed and merged on the remote main branch

It is useful to clean up unnecessary local branches that pollute the ```git branch -a``` and autocomplete for other commands.