### PR TITLE
fix Client compilation errors

### DIFF
--- a/src/client/Client.cpp
+++ b/src/client/Client.cpp
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   Client.cpp                                         :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: djames <djames@student.hive.fi>            +#+  +:+       +#+        */
+/*   By: malaakso <malaakso@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/20 10:44:08 by djames            #+#    #+#             */
-/*   Updated: 2024/02/20 16:36:30 by djames           ###   ########.fr       */
+/*   Updated: 2024/02/21 07:34:48 by malaakso         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,16 +14,17 @@
 
 namespace irc {
 
-Client::Client(int clientSocket) : socket_(clientSocket) {
+Client::Client(int clientSocket) : fd_(clientSocket) {
   status_.gotUser = false;
   status_.gotNick = false;
   status_.gotPassword = false;
   status_.authenticated = false;
+  fd_ = 0; 
 }
 
 Client::~Client() {
-  if (socket_ != SOCKET_FAILURE) {
-    close(socket_);
+  if (fd_ != SOCKET_FAILURE) {
+    close(fd_);
   }
 }
 
@@ -78,8 +79,8 @@ std::string Client::getUserName() const {
   return userName_;
 }
 
-int Client::getSocket() const {
-  return socket_;
+int Client::getFd() const {
+  return fd_;
 }
 
 void Client::setSendBuffer(const std::string& sendBuffer) {

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   Client.h                                           :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: djames <djames@student.hive.fi>            +#+  +:+       +#+        */
+/*   By: malaakso <malaakso@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/12 16:12:46 by djames            #+#    #+#             */
-/*   Updated: 2024/02/20 16:34:28 by djames           ###   ########.fr       */
+/*   Updated: 2024/02/21 07:35:33 by malaakso         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,10 +15,11 @@
 
 #include <sys/poll.h>
 #include <sys/socket.h>
+#include <unistd.h>
 #include <string>
 #include <vector>
-#include "../common/magicNumber.h"
 #include "../common/log.h"
+#include "../common/magicNumber.h"
 
 namespace irc {
 
@@ -27,7 +28,7 @@ class Client {
   Client(int clientSocket);
 
   ~Client();
-  int getSocket() const;
+  int getFd() const;
 
   void setSendBuffer(const std::string& sendBuffer);
   std::string getSendBuffer() const;
@@ -51,9 +52,8 @@ class Client {
 
  private:
   void setOldNickname(const std::string& oldNickname);
-  int socket_;
+  int fd_;
   std::string nickname_;
-  int clientFd_;
   std::string oldNickname_;
   std::string userName_;
   std::string sendBuffer_;


### PR DESCRIPTION
The Client class had some compilation errors, at least due to an unused variable (there was `int socket_`, and `int clientFd_`), and a missing header (`unistd.h` for `close()`).

Fixed those to make the project compile with make and make test.

I chose `fd_` to be the variable name for the socket or the client fd, because you can refer to it with `this->fd_` or externally just with `client.getFd()`