### PR TITLE
fix multichar char compilation error

### DIFF
--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -78,7 +78,7 @@ int main(int argc, char** argv) {
     return EXIT_FAILURE;
   }
   LOG_INFO("server starting on port " << argv[1]);
-  LOG_DEBUG('with password ")' << argv[2] << '"');
+  LOG_DEBUG("with password \")" << argv[2] << "\"");
 
   signal(SIGINT, signalHandler);   // Ctrl+C
   signal(SIGTERM, signalHandler);  // kill


### PR DESCRIPTION
Fixes a compilation error that has been fixed before as well...
This fix makes the string in question be a standard string with escape characters for double quotes inside of the string.
Previous non-fixes:
- String in raw format - clangd on Apple silicon complains
- String with single quotes - doesn't compile on Intel