### PR TITLE
Fix: Replies 1-4 IRCv3, myClients to allClients, missing client_

### DIFF
--- a/src/command/Command.cpp
+++ b/src/command/Command.cpp
@@ -40,11 +40,11 @@ std::map<std::string, std::function<void(Command*, Client&)>>
                           }}};
 
 Command::Command(const Message& commandString, Client& client,
-                 std::map<int, Client>& myClients, std::string& password,
+                 std::map<int, Client>& allClients, std::string& password,
                  time_t& serverStartTime,
                  std::map<std::string, Channel>& allChannels)
     : client_(client),
-      allClients_(myClients),
+      allClients_(allClients),
       allChannels_(allChannels),
       pass_(password),
       serverStartTime_(serverStartTime) {
@@ -355,7 +355,7 @@ void Command::actionPrivmsg(Client& client) {
                             serverHostname_g);  // TODO: fix in channel branch
   std::string privmsg =
       PRIVMSG_FORMAT(formattedSender, targetRecipient, messageWithoutColon);
-  myClients_.find(target)->second.appendToSendBuffer(privmsg);
+  allClients_.find(target)->second.appendToSendBuffer(privmsg);
   LOG_DEBUG("CMD::PRIVMSG _____ END _____");
 }
 

--- a/src/command/Command.cpp
+++ b/src/command/Command.cpp
@@ -303,7 +303,9 @@ void Command::actionPrivmsg(Client& client) {
     return;
   }
   if (amountParameters > 2) {
-    client.appendToSendBuffer(RPL_ERR_TOOMANYTARGETS_407(serverHostname_g, param_.at(1), std::to_string(param_.size() - 1), "Only one target per message."));
+    client.appendToSendBuffer(RPL_ERR_TOOMANYTARGETS_407(
+        serverHostname_g, param_.at(1), std::to_string(param_.size() - 1),
+        "Only one target per message."));
     LOG_DEBUG("CMD::PRIVMSG::TOO MANY TARGETS");
     return;
   }
@@ -357,7 +359,6 @@ void Command::actionPrivmsg(Client& client) {
   LOG_DEBUG("CMD::PRIVMSG _____ END _____");
 }
 
-
 int Command::findClientByNickname(const std::string& nickname) {
   std::string lowerNickname =
       nickname;  //here we just put everything in lowercase
@@ -408,16 +409,17 @@ bool Command::isValidNickname(std::string& nickname) {
 }
 
 void Command::sendAuthReplies_(Client& client) {
+  std::string clientNick = client.getNickname();
+  client.appendToSendBuffer(RPL_WELCOME_001(
+      serverHostname_g, clientNick, client.getUserName(), client.getHost()));
   client.appendToSendBuffer(
-      RPL_WELCOME_001(serverHostname_g, client.getNickname(),
-                      client.getUserName(), client.getHost()));
-  client.appendToSendBuffer(
-      RPL_YOURHOST_002(serverHostname_g, IRC_SERVER_VERSION));
+      RPL_YOURHOST_002(serverHostname_g, clientNick, IRC_SERVER_VERSION));
   std::string time = std::string(ctime(&serverStartTime_));
   time.pop_back();  // Remove the newline character
-  client.appendToSendBuffer(RPL_CREATED_003(serverHostname_g, time));
-  client.appendToSendBuffer(RPL_MYINFO_004(serverHostname_g, IRC_SERVER_VERSION,
-                                           SUPPORTED_USER_MODES,
-                                           SUPPORTED_CHANNEL_MODES));
+  client.appendToSendBuffer(
+      RPL_CREATED_003(serverHostname_g, clientNick, time));
+  client.appendToSendBuffer(
+      RPL_MYINFO_004(serverHostname_g, clientNick, IRC_SERVER_VERSION,
+                     SUPPORTED_USER_MODES, SUPPORTED_CHANNEL_MODES));
 }
 }  // namespace irc

--- a/src/command/Command.h
+++ b/src/command/Command.h
@@ -48,6 +48,7 @@ class Command {
   std::string commandName_;
   std::vector<std::string> param_;
   int numeric_;
+  Client& client_;
   std::map<int, Client>& allClients_;
   std::map<std::string, Channel>& allChannels_;
   std::string& pass_;

--- a/src/common/reply.h
+++ b/src/common/reply.h
@@ -8,10 +8,10 @@
 #define RPL_MESSAGE(message) (std::string(message) + "\r\n")
 
 // Numeric replies in order
-#define RPL_WELCOME_001(servername, nick, user, host) (RPL_META_MESSAGE(servername, "001", ":Welcome to the Internet Relay Network " + nick + "!" + user + "@" + host))
-#define RPL_YOURHOST_002(servername, version) (RPL_META_MESSAGE(servername, "002", ":Your host is " + servername + ", running version " + version))
-#define RPL_CREATED_003(servername, date) (RPL_META_MESSAGE(servername, "003", ":This server was created " + date))
-#define RPL_MYINFO_004(servername, version, user_modes, channel_modes) (RPL_META_MESSAGE(servername, "004", servername + " " + version + " " + user_modes + " " + channel_modes))
+#define RPL_WELCOME_001(servername, nick, user, host) (RPL_META_MESSAGE(servername, "001", nick + " :Welcome to the Internet Relay Network " + nick + "!" + user + "@" + host))
+#define RPL_YOURHOST_002(servername, nick, version) (RPL_META_MESSAGE(servername, "002", nick + " :Your host is " + servername + ", running version " + version))
+#define RPL_CREATED_003(servername, nick, date) (RPL_META_MESSAGE(servername, "003", nick + " :This server was created " + date))
+#define RPL_MYINFO_004(servername, nick, version, user_modes, channel_modes) (RPL_META_MESSAGE(servername, "004", nick + " " + servername + " " + version + " " + user_modes + " " + channel_modes))
 
 #define RPL_NOTOPIC_331(servername, channel) (RPL_META_MESSAGE(servername, "331", channel + " :No topic is set"))
 #define RPL_TOPIC_332(servername, channel, topic) (RPL_META_MESSAGE(servername, "332", channel + " :" + topic))
@@ -40,6 +40,5 @@
 //User format
 #define FORMAT_NICK_USER_HOST(nickname, username, hostname) (std::string(":") + nickname + "!" + username + "@" + hostname)
 #define PRIVMSG_FORMAT(formattedSender, target, text) (RPL_MESSAGE(std::string(formattedSender) + " PRIVMSG " + target + " :" + text))
-
 
 #endif


### PR DESCRIPTION
## Fixed these:

- Replies 1-4 were not compliant with IRCv3, due to that, irssi was not showing nicknames correctly
- Command class had myClients renamed to allClients, resulting in some functions having references to deprecated myClients
- Command class was missing private member client_, which refers to the client that sent the command, that is used in some member functions

Resolves #40 and resolves #43 
