### PR TITLE
Fix Channel messaging and refactor Command a bit

### DIFF
--- a/src/channel/Channel.h
+++ b/src/channel/Channel.h
@@ -40,7 +40,7 @@ class Channel {
   void uninvite(Client& client);
   bool isInvited(Client& client);
   unsigned long getMemberCount() const;
-  std::vector<Client>& getMembers();
+  std::vector<Client*>& getMembers();
   std::string getNamesList();
   static bool isChannelNameValid(const std::string& name);
   static bool isChannelNameFree(const std::string& name,
@@ -48,9 +48,9 @@ class Channel {
 
  private:
   std::string name_;
-  std::vector<Client> invited_;
-  std::vector<Client> members_;
-  std::vector<Client> operators_;
+  std::vector<Client*> invited_;
+  std::vector<Client*> members_;
+  std::vector<Client*> operators_;
   std::string topic_;
   std::string key_;
   bool isInviteOnly_;

--- a/src/client/Client.cpp
+++ b/src/client/Client.cpp
@@ -168,6 +168,16 @@ void Client::setDisconnectReason(const std::string& reason) {
   disconnectReason_ = reason;
 }
 
+std::string Client::getDisconnectErrorReason() const {
+  return disconnectErrorReason_;
+}
+
+void Client::setDisconnectErrorReason(const std::string& reason) {
+  LOG_DEBUG("Client::setDisconnectErrorReason: nick"
+            << nickname_ << " set disconnectErrorReason: " << reason);
+  disconnectErrorReason_ = reason;
+}
+
 void Client::recordMyChannel(std::string& channelName) {
   myChannelsByName_.push_back(channelName);
   LOG_DEBUG("Client::recordMyChannel: nick "
@@ -189,6 +199,13 @@ void Client::unrecordMyChannel(std::string& channelName) {
 
 std::vector<std::string>& Client::getMyChannels() {
   return myChannelsByName_;
+}
+
+void Client::processErrorMessage() {
+  if (disconnectErrorReason_.empty() == false) {
+    sendBuffer_ += ERR_MESSAGE(disconnectErrorReason_);
+    disconnectErrorReason_.clear();
+  }
 }
 
 }  // namespace irc

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -10,6 +10,7 @@
 
 #include "../common/log.h"
 #include "../common/magicNumber.h"
+#include "../common/reply.h"
 
 namespace irc {
 
@@ -43,10 +44,13 @@ class Client {
   bool getWantDisconnect() const;
   std::string getDisconnectReason() const;
   void setDisconnectReason(const std::string& reason);
+  std::string getDisconnectErrorReason() const;
+  void setDisconnectErrorReason(const std::string& reason);
   void recordMyChannel(std::string& channel);
   void unrecordMyChannel(std::string& channel);
   std::vector<std::string>& getMyChannels();
   std::string& getHost();
+  void processErrorMessage();
 
  private:
   void setOldNickname_(const std::string& oldNickname);
@@ -61,6 +65,7 @@ class Client {
   std::string recvBuffer_;
   std::string password_;
   std::string disconnectReason_;
+  std::string disconnectErrorReason_;
   std::string ipAddr_;
 
   std::vector<std::string> myChannelsByName_;

--- a/src/command/Command.cpp
+++ b/src/command/Command.cpp
@@ -290,7 +290,7 @@ void Command::actionQuit(Client& client) {
     Channel& channel = allChannels_.at(channelName);
     channel.sendMessageToMembers(
         COM_MESSAGE(client.getNickname(), client.getUserName(),
-                    client.getHost(), "QUIT", quitReason));
+                    client.getHost(), "QUIT", ":" + quitReason));
   }
 
   // Send the ERROR message to the client and disconnect

--- a/src/command/Command.cpp
+++ b/src/command/Command.cpp
@@ -230,7 +230,7 @@ void Command::actionPart(Client& client) {
       continue;
     }
 
-    Channel currentChannel = allChannels_.at(channelName);
+    Channel& currentChannel = allChannels_.at(channelName);
     if (currentChannel.isMember(client) == false) {
       client.appendToSendBuffer(
           RPL_ERR_NOTONCHANNEL_442(serverHostname_g, channelName));

--- a/src/command/Command.h
+++ b/src/command/Command.h
@@ -55,7 +55,6 @@ class Command {
   time_t serverStartTime_;
 
   Client& findClientByNicknameOrThrow(const std::string& nickname);
-  void parseCommand(const Message& commandString, Client& client);
   void sendAuthReplies_(Client& client);
   static std::map<std::string, std::function<void(Command*, Client&)>> commands;
   bool isValidNickname(std::string& nickname);

--- a/src/command/actionJoin.cpp
+++ b/src/command/actionJoin.cpp
@@ -21,7 +21,7 @@ void Command::actionJoin(Client& client) {
         continue;
       }
 
-      Channel currentChannel = allChannels_.at(channelName);
+      Channel& currentChannel = allChannels_.at(channelName);
       if (currentChannel.isMember(client) == false) {
         LOG_ERROR(
             "Command::actionJoin: Client is not a member of the channel that "
@@ -77,7 +77,7 @@ void Command::actionJoin(Client& client) {
     }
 
     if (Channel::isChannelNameFree(channelName, allChannels_) == false) {
-      Channel existingChannel = allChannels_.at(channelName);
+      Channel& existingChannel = allChannels_.at(channelName);
       if (channelKey != existingChannel.getKey()) {
         client.appendToSendBuffer(
             RPL_ERR_BADCHANNELKEY_475(serverHostname_g, channelName));
@@ -102,7 +102,7 @@ void Command::actionJoin(Client& client) {
           channelName, Channel(client, channelName, allChannels_)));
     }
 
-    Channel currentChannel = allChannels_.at(channelName);
+    Channel& currentChannel = allChannels_.at(channelName);
     // Join message for the channel, and as a reply to the client
     currentChannel.sendMessageToMembers(
         COM_MESSAGE(client.getNickname(), client.getUserName(),

--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -313,7 +313,7 @@ int Server::disconnectClient_(std::vector<pollfd>& poll_fds,
   // Remove client from all channels
   std::vector<std::string> channelNames = client.getMyChannels();
   for (std::string channelName : channelNames) {
-    Channel channel = channels_.at(channelName);
+    Channel& channel = channels_.at(channelName);
     channel.partMember(client);
   }
   unsigned long clients_erased = clients_.erase(client_fd);


### PR DESCRIPTION
# Done in this PR:

- Removed a passthrough function in Command
- Fixed the issue where users on a channel could not see each other's messages (was creating a deep copy of the clients in the Channels vectors, where a shallow copy was proper)
- Fixed the QUIT message propagation in channels when clients close their socket (Ctrl-C in netcat), it now happens automatically in the Server class.
- Refactor and possibly fix Channel::setOperatorStatus
- Implemented an easy way to display the fatal `ERROR <reason>` before disconnecting the client, using `client.setDisconnectErrorReason()`... After wantDisconnect is set, the ERROR message will be displayed as intended before closing the client socket.