### PR TITLE
Fix: make test compilation (on Apple Silicon at least)

### DIFF
--- a/test/command/testCommandClass.cpp
+++ b/test/command/testCommandClass.cpp
@@ -73,12 +73,13 @@ TEST_CASE("Command PRIVMSG action", "[command][privmsg]") {
   random.setUserName("randomU");
   random.setNickname("randomN");
   std::map<int, Client> myClients = {{1, sender}, {2, receiver}, {3, random}};
+  std::map<std::string, Channel> myChannels;
 
   SECTION("PRIVMSG - Valid") {
     std::string response = ":senderN!senderU@" + serverHostname_g + " PRIVMSG receiverN :A valid message!\r\n";
     std::string msgWithoutParameters = "PRIVMSG receiverN :A valid message!";
     Message msg(msgWithoutParameters);
-    Command cmd(msg, sender, myClients, password, serverStartTime);
+    Command cmd(msg, sender, myClients, password, serverStartTime, myChannels);
     std::vector<std::string>  param_ = msg.getParameters(); 
     REQUIRE(myClients.find(2)->second.getSendBuffer() == response);
     REQUIRE(sender.getSendBuffer() == "");
@@ -88,7 +89,7 @@ TEST_CASE("Command PRIVMSG action", "[command][privmsg]") {
     std::string response = ": 411 :No recipient given (privmsg)\r\n";
     std::string msgWithoutParameters = "PRIVMSG";
     Message msg(msgWithoutParameters);
-    Command cmd(msg, sender, myClients, password, serverStartTime);
+    Command cmd(msg, sender, myClients, password, serverStartTime, myChannels);
     REQUIRE(sender.getSendBuffer() == response);
   }
 
@@ -96,7 +97,7 @@ TEST_CASE("Command PRIVMSG action", "[command][privmsg]") {
     std::string response = ": 407 client2 :3 recipients. Only one target per message.\r\n";
     std::string msgWithTooManyTargets = "PRIVMSG client1 client2 client3 :message";
     Message msg(msgWithTooManyTargets);
-    Command cmd(msg, sender, myClients, password, serverStartTime);
+    Command cmd(msg, sender, myClients, password, serverStartTime, myChannels);
     REQUIRE(sender.getSendBuffer() == response);
   }
 
@@ -104,7 +105,7 @@ TEST_CASE("Command PRIVMSG action", "[command][privmsg]") {
     std::string response = ": 412 :No text to send\r\n";
     std::string msgWithNoTextToSend = "PRIVMSG client";
     Message msg(msgWithNoTextToSend);
-    Command cmd(msg, sender, myClients, password, serverStartTime);
+    Command cmd(msg, sender, myClients, password, serverStartTime, myChannels);
     REQUIRE(sender.getSendBuffer() == response);
   }
 
@@ -112,7 +113,7 @@ TEST_CASE("Command PRIVMSG action", "[command][privmsg]") {
     std::string response = ": 412 :No text to send\r\n";
     std::string msgWithNoTextToSend = "PRIVMSG sender message";
     Message msg(msgWithNoTextToSend);
-    Command cmd(msg, sender, myClients, password, serverStartTime);
+    Command cmd(msg, sender, myClients, password, serverStartTime, myChannels);
     REQUIRE(sender.getSendBuffer() == response);
   }
 
@@ -120,7 +121,7 @@ TEST_CASE("Command PRIVMSG action", "[command][privmsg]") {
     std::string response = ": 401 blah :No such nick/channel\r\n";
     std::string msgWithNonExistingNickname = "PRIVMSG blah :a message";
     Message msg(msgWithNonExistingNickname);
-    Command cmd(msg, sender, myClients, password, serverStartTime);
+    Command cmd(msg, sender, myClients, password, serverStartTime, myChannels);
     REQUIRE(sender.getSendBuffer() == response);
   }
 

--- a/test/command/testCommandClass.cpp
+++ b/test/command/testCommandClass.cpp
@@ -76,11 +76,12 @@ TEST_CASE("Command PRIVMSG action", "[command][privmsg]") {
   std::map<std::string, Channel> myChannels;
 
   SECTION("PRIVMSG - Valid") {
-    std::string response = ":senderN!senderU@" + sender.getHost() + " PRIVMSG receiverN :A valid message!\r\n";
+    std::string response = ":senderN!senderU@" + sender.getHost() +
+                           " PRIVMSG receiverN :A valid message!\r\n";
     std::string msgWithoutParameters = "PRIVMSG receiverN :A valid message!";
     Message msg(msgWithoutParameters);
     Command cmd(msg, sender, myClients, password, serverStartTime, myChannels);
-    std::vector<std::string>  param_ = msg.getParameters(); 
+    std::vector<std::string> param_ = msg.getParameters();
     REQUIRE(myClients.find(2)->second.getSendBuffer() == response);
     REQUIRE(sender.getSendBuffer() == "");
   }
@@ -94,8 +95,10 @@ TEST_CASE("Command PRIVMSG action", "[command][privmsg]") {
   }
 
   SECTION("PRIVMSG - too many parameters -> 407 TOOMANYTARGETS") {
-    std::string response = ": 407 client2 :3 recipients. Only one target per message.\r\n";
-    std::string msgWithTooManyTargets = "PRIVMSG client1 client2 client3 :message";
+    std::string response =
+        ": 407 client2 :3 recipients. Only one target per message.\r\n";
+    std::string msgWithTooManyTargets =
+        "PRIVMSG client1 client2 client3 :message";
     Message msg(msgWithTooManyTargets);
     Command cmd(msg, sender, myClients, password, serverStartTime, myChannels);
     REQUIRE(sender.getSendBuffer() == response);
@@ -124,5 +127,4 @@ TEST_CASE("Command PRIVMSG action", "[command][privmsg]") {
     Command cmd(msg, sender, myClients, password, serverStartTime, myChannels);
     REQUIRE(sender.getSendBuffer() == response);
   }
-
 }

--- a/test/command/testCommandClass.cpp
+++ b/test/command/testCommandClass.cpp
@@ -76,7 +76,7 @@ TEST_CASE("Command PRIVMSG action", "[command][privmsg]") {
   std::map<std::string, Channel> myChannels;
 
   SECTION("PRIVMSG - Valid") {
-    std::string response = ":senderN!senderU@" + serverHostname_g + " PRIVMSG receiverN :A valid message!\r\n";
+    std::string response = ":senderN!senderU@" + sender.getHost() + " PRIVMSG receiverN :A valid message!\r\n";
     std::string msgWithoutParameters = "PRIVMSG receiverN :A valid message!";
     Message msg(msgWithoutParameters);
     Command cmd(msg, sender, myClients, password, serverStartTime, myChannels);

--- a/test/server/testServer.cpp
+++ b/test/server/testServer.cpp
@@ -6,6 +6,7 @@
 #include "../../src/common/magicNumber.h"
 
 TEST_CASE("server is started properly", "[server]") {
+  errno = 0;
   char port[] = "6667";
   std::string password = "horse";
   irc::Server server(port, password);


### PR DESCRIPTION
Issues with compilation and tests passing were related to:

- Command class constructor changes
- Difference between Apple Silicon and Intel macs: some networking functions do not reset the errno to 0 on Apple Silicon, while they do on Intel macs. There was a test assuming errno was going to be set to 0 by a networking function, which was incorrect on Apple Silicon.
- Assumption in tests related to PRIVMSG that the sender prefix is `:senderNick!senderUser@serverHost`, when in reality the sender prefix is `:senderNick!senderUser@senderHost`, leading to a failing testcase.