### PR TITLE
Continuous Integration Feature: Running tests before merging

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,18 @@
+name: ft_irc tests
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: make test
+      run: make test
+

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,4 +1,4 @@
-name: ft_irc tests
+name: ft_irc unit tests
 
 on:
   push:


### PR DESCRIPTION
This PR configures the main branch to run `make test` before pushes to it, or before merging a PR into it.

We can later configure GitHub to enforce passing tests before allowing a merge to happen.

This will also help ensure that merging with main doesn't break existing tests and code.
Even if make test passes when the pull request is created: If at some point, the merging is blocked due to merge conflicts and those conflicts are resolved, the make test will be forced to run again before allowing a merge. (hopefully catching any mistakes with it)

We could also maybe implement another check later on, that will try to merge the branch PR into the main, if any conflicts, compilation issues, make test issues arise, then it would fail and otherwise pass.