### PR TITLE
QoL: change ColumnLimit and IndentWidth

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -44,7 +44,7 @@ BreakBeforeBinaryOperators: None
 BreakBeforeTernaryOperators: true
 BreakConstructorInitializers: BeforeColon
 BreakInheritanceList: BeforeColon
-ColumnLimit: 80
+ColumnLimit: 140
 CompactNamespaces: false
 ContinuationIndentWidth: 4
 Cpp11BracedListStyle: true
@@ -54,7 +54,7 @@ FixNamespaceComments: true
 IncludeBlocks: Preserve
 IndentCaseLabels: true
 IndentPPDirectives: None
-IndentWidth: 2
+IndentWidth: 4
 KeepEmptyLinesAtTheStartOfBlocks: true
 MaxEmptyLinesToKeep: 1
 NamespaceIndentation: None


### PR DESCRIPTION
# Quality of Life improvement

- Column limit is now 140 (from 80), so that C++ functions are easier to read.
_I did not go for 200 due to the fact that it would require scrolling sideways in some cases, on my 14" laptop with VSCode in fullscreen and fontsize 16._
- Indent width is now 4 spaces (from 2), so that the control flow is easier to follow.

The reformatting will be done on the whole codebase in a seperate PR.