### PR TITLE
Test/command/nick + reodering of reply.h + replace magic number with NICK_MAX_LENGTH_RFC2812

### DIFF
--- a/src/command/Command.cpp
+++ b/src/command/Command.cpp
@@ -288,7 +288,7 @@ Client& Command::findClientByNicknameOrThrow(const std::string& nickname) {
 
 bool Command::isValidNickname(std::string& nickname) {
     std::regex pattern(R"(^[a-zA-Z\[\]\\`_^{|}])");
-    std::regex pattern1(R"(^[a-zA-Z0-9\[\]\\,`_^{|}-]*$)");
+    std::regex pattern1(R"(^[a-zA-Z0-9\[\]\\`_^{|}-]*$)");
     if (!std::regex_match(nickname.substr(0, 1), pattern)) {
         return false;
     }

--- a/src/command/Command.cpp
+++ b/src/command/Command.cpp
@@ -286,6 +286,17 @@ Client& Command::findClientByNicknameOrThrow(const std::string& nickname) {
     throw std::out_of_range(std::string("Command::findClientByNicknameOrThrow: ") + nickname + " not found");
 }
 
+/**
+*   Nick name validity is checked according to RFC2812 p. 7:
+*   nickname   =  ( letter / special ) *8( letter / digit / special / "-" )
+*   where,
+*
+*       special = %x5B-60 / %x7B-7D 
+*       ; "[", "]", "\", "‘", "_", "^", "{", "|", "}"
+*   
+*   Exception is made for spaces which we accept as DALnet does, i.e. using the 
+*   space as a delimiter setting the nick to the first delimited word.
+*/
 bool Command::isValidNickname(std::string& nickname) {
     std::regex pattern(R"(^[a-zA-Z\[\]\\`_^{|}])");
     std::regex pattern1(R"(^[a-zA-Z0-9\[\]\\`_^{|}-]*$)");

--- a/src/command/Command.cpp
+++ b/src/command/Command.cpp
@@ -121,7 +121,6 @@ void Command::actionNick(Client& client) {
     if (client.isGotPassword() == false) {
         client.appendToSendBuffer(ERR_MESSAGE("You must send a password first"));
         client.setWantDisconnect();
-
         return;
     }
     if (param_.size() == 0) {
@@ -142,7 +141,6 @@ void Command::actionNick(Client& client) {
     } catch (std::out_of_range& e) {
         ;  // The nickname is not in use
     }
-    LOG_DEBUG_HL("enter to this part it should not come here");
     client.setNickname(param_.at(0));
     if (isAlreadyAuthenticated == false && client.isAuthenticated()) {
         sendAuthReplies_(client);
@@ -280,7 +278,7 @@ void Command::actionQuit(Client& client) {
  * match the IRC specification. If the client is found, it returns a reference to the
  * client. If not, it throws an std::out_of_range exception.
  *
- * @param nickname The nickname to search for.
+ * @param  The nickname to search for.
  * @return A reference to the client with the matching nickname.
  * @throws std::out_of_range if the client is not found.
  */

--- a/src/common/reply.h
+++ b/src/common/reply.h
@@ -35,6 +35,8 @@
 
 #define RPL_ERR_UNKNOWNCOMMAND_421(servername, command) (RPL_META_MESSAGE(servername, "421", command + " :Unknown command"))
 #define RPL_ERR_NONICKNAMEGIVEN_431(servername) (RPL_META_MESSAGE(servername, "431", ":No nickname given"))
+#define RPL_ERR_ERRONEUSNICKNAME_432(servername, nick) (RPL_META_MESSAGE(servername, "432", nick + " :Erroneous nickname"))
+#define RPL_ERR_NICKNAMEINUSE_433(servername, nick) (RPL_META_MESSAGE(servername, "433", nick + " :Nickname is already in use"))
 #define RPL_ERR_NOTONCHANNEL_442(servername, channel) (RPL_META_MESSAGE(servername, "442", channel + " :You're not on that channel"))
 #define RPL_ERR_NOTREGISTERED_451(servername) (RPL_META_MESSAGE(servername, "451", ":You have not registered"))
 #define RPL_ERR_NEEDMOREPARAMS_461(servername, command) (RPL_META_MESSAGE(servername, "461", command + " :Not enough parameters"))
@@ -42,8 +44,6 @@
 #define RPL_ERR_CHANNELISFULL_471(servername, channel) (RPL_META_MESSAGE(servername, "471", channel + " :Cannot join channel (+l)"))
 #define RPL_ERR_INVITEONLYCHAN_473(servername, channel) (RPL_META_MESSAGE(servername, "473", channel + " :Cannot join channel (+i)"))
 #define RPL_ERR_BADCHANNELKEY_475(servername, channel) (RPL_META_MESSAGE(servername, "475", channel + " :Cannot join channel (+k)"))
-#define RPL_ERR_ERRONEUSNICKNAME_432(servername, nick) (RPL_META_MESSAGE(servername, "432", nick + " :Erroneous nickname"))
-#define RPL_ERR_NICKNAMEINUSE_433(servername, nick) (RPL_META_MESSAGE(servername, "433", nick + " :Nickname is already in use"))
 
 //User format
 #define FORMAT_NICK_USER_HOST(nickname, username, hostname) (std::string(":") + nickname + "!" + username + "@" + hostname)

--- a/test/command/testCommandClass.cpp
+++ b/test/command/testCommandClass.cpp
@@ -7,6 +7,8 @@
 #include "../../src/message/Message.h"
 
 extern std::string serverHostname_g;
+std::string password = "password";
+
 using namespace irc;
 
 // TEST_CASE("Command class works as expected", "[command]") {
@@ -56,14 +58,19 @@ struct NicknameTestData {
     bool isValid;
 };
 
-std::vector<NicknameTestData> nicknameTestData = {
-    {"Valid Nickname", "nick", true},         {"Truncated Nickname", "longerThanNineNick", true},
-    {"Contains a space ' '", "a nick", true}, {"Empty Nickname", "", false},
-    {"Contains ','", "a,nick", false},        {"Contains Asterisk", "a*nick", false},
-    {"Contains '?'", "a?Nick", false},        {"contains '!' ", "a!nick", false},
-    {"Contains '@'", "a@nick", false},        {"Contains a '.'", "a.nick", false},
-    {"Contains '$'", "a$nick", false},        {"Contains a ':'", "a:nick", false},
-    {"Contains '&'", "a&nick", false}};
+std::vector<NicknameTestData> nicknameTestData = {{"Valid Nickname", "nick", true},
+                                                  {"Truncated Nickname", "longerThanNineNick", true},
+                                                  {"Contains a space ' '", "a nick", true},
+                                                  {"Contains ','", "a,nick", false},
+                                                  {"Empty ", "", false},
+                                                  {"Contains Asterisk", "a*nick", false},
+                                                  {"Contains '?'", "a?Nick", false},
+                                                  {"contains '!' ", "a!nick", false},
+                                                  {"Contains '@'", "a@nick", false},
+                                                  {"Contains a '.'", "a.nick", false},
+                                                  {"Contains '$'", "a$nick", false},
+                                                  {"Contains a ':'", "a:nick", false},
+                                                  {"Contains '&'", "a&nick", false}};
 
 /**
 *   Nick name validity is checked according to RFC2812 p. 7:
@@ -75,14 +82,16 @@ std::vector<NicknameTestData> nicknameTestData = {
 *   
 *   Exception is made for spaces which we accept as DALnet does, i.e. using the 
 *   space as a delimiter setting the nick to the first delimited word.
+*
+*   A nickname can be of maximum 9 characters long
 */
 TEST_CASE("Nick", "[command][nick]") {
     int errno_before = errno;
     REQUIRE(errno == errno_before);
     time_t serverStartTime = time(NULL);
-    std::string password = "password";
     struct sockaddr sockaddr;
     std::map<std::string, Channel> myChannels;
+    std::string response;
 
     Client client1(1, sockaddr);
     client1.setPassword("client1P");
@@ -100,7 +109,8 @@ TEST_CASE("Nick", "[command][nick]") {
             for (const auto& data : nicknameTestData) {
                 if (data.isValid) {
                     std::string msg = "NICK " + data.nickname;
-                    std::string truncatedNick = data.nickname.substr(0, 9);  // Truncate nick to autorized max nick length = 9 characters
+                    std::string truncatedNick =
+                        data.nickname.substr(0, NICK_MAX_LENGTH_RFC2812);  // Truncate nick to autorized max nick length = 9 characters
                     size_t pos = truncatedNick.find_first_of(
                         " ");  // We decided to accept space as a delimiter as DalNet does, hence the two following functions
                     std::string expectedNick = truncatedNick.substr(0, pos);  // Split from white space
@@ -109,21 +119,38 @@ TEST_CASE("Nick", "[command][nick]") {
                     Command cmd(msg, client1, myClients, password, serverStartTime, myChannels);
                     INFO(data.description + " failed to set nickname to: \"" + expectedNick + "\"");
                     REQUIRE(client1.getNickname() == expectedNick);
+                    REQUIRE(client1.getNickname().length() <= NICK_MAX_LENGTH_RFC2812);
                 }
             }
         }
-
         WHEN("Setting an invalid nickname") {
             for (const auto& data : nicknameTestData) {
                 if (!data.isValid) {
+                    if (data.nickname.length() == 0) {
+                        response = ": 431 :No nickname given\r\n";
+                    } else {
+                        response = ": 432 " + data.nickname + " :Erroneous nickname\r\n";
+                    }
                     std::string msg = "NICK " + data.nickname;
-                    std::string truncatedNick = data.nickname.substr(0, 9);
+                    std::string truncatedNick = data.nickname.substr(0, NICK_MAX_LENGTH_RFC2812);
                     std::string originalNick = client1.getNickname();
+                    client1.clearSendBuffer();
                     Command cmd(msg, client1, myClients, password, serverStartTime, myChannels);
                     INFO(data.description + " nickname should remained unchanged to: " + client1.getNickname());
+                    REQUIRE(client1.getSendBuffer() == response);
                     REQUIRE(client1.getNickname() == originalNick);
+                    REQUIRE(client1.getNickname().length() <= NICK_MAX_LENGTH_RFC2812);
                 }
             }
+        }
+        WHEN("Setting a nickname that is already in use") {
+            std::string originalNick = client1.getNickname();
+            std::string existingNick = client2.getNickname();
+            std::string msg = "NICK " + existingNick;
+            response = ": 433 " + existingNick + " :Nickname is already in use\r\n";
+            Command cmd(msg, client1, myClients, password, serverStartTime, myChannels);
+            REQUIRE(client1.getSendBuffer() == response);
+            REQUIRE(client1.getNickname() == originalNick);
         }
     }
 }
@@ -132,7 +159,6 @@ TEST_CASE("Command PRIVMSG action", "[command][privmsg]") {
     int errno_before = errno;
     REQUIRE(errno == errno_before);
     time_t serverStartTime = time(NULL);
-    std::string password = "password";
     struct sockaddr sockaddr;
 
     Client sender(1, sockaddr);

--- a/test/command/testCommandClass.cpp
+++ b/test/command/testCommandClass.cpp
@@ -50,10 +50,79 @@ using namespace irc;
 //   }
 
 // }
+
+TEST_CASE("Nick", "[command][nick]") {
+    int errno_before = errno;
+    REQUIRE(errno == errno_before);
+    time_t serverStartTime = time(NULL);
+    std::string password = "password";
+    struct sockaddr sockaddr;
+    std::map<std::string, Channel> myChannels;
+
+    std::string msgNick = "NICK "; //sets message's commmand to NICK
+    //valid according to IRCv3
+    std::string validNick = "nick";
+    std::string truncateNick = "longerThanNineNick";
+    std::string containsSpace = "a nick"; // Dalnet accepts this, it is against RFC.
+    //invalid according to IRCv3
+    std::string emptyNick = "";
+    std::string containsComma = "a,nick";
+    std::string containsAnAsterisk = "a*nick";
+    std::string containsAQuestionMark = "a?Nick";
+    std::string containsAnExclamationMark = "a!nick";
+    std::string containsAnAtSign = "@nick";
+    std::string containsADot = "ni.ck";
+    std::string startsWithADollar = "$nick";
+    std::string startsWithAColon = ":nick";
+    std::string startsWithAnAmpersand = "&nick";
+
+    Client client1(1, sockaddr);
+    client1.setPassword("client1P");
+    client1.setUserName("client1U");
+    client1.setNickname("client1N");
+
+    Client client2(2, sockaddr);
+    client2.setPassword("client2P");
+    client2.setUserName("client2U");
+    client2.setNickname("client2N");
+    std::map<int, Client> myClients = {{1, client1}, {2, client2}};
+
+    SECTION("Nick-Valid") {
+        Command cmd_1(msgNick + validNick, client1, myClients, password, serverStartTime, myChannels);
+        REQUIRE(client1.getNickname() == validNick);
+        Command cmd_2(msgNick + truncateNick, client1, myClients, password, serverStartTime, myChannels);
+        REQUIRE(client1.getNickname() == "longerTha");
+        Command cmd_3(msgNick + containsSpace, client1, myClients, password, serverStartTime, myChannels);
+        REQUIRE(client1.getNickname() == "a");
+    }
+
+    SECTION("Nick-Invalid") {
+        Command cmd_1(msgNick + emptyNick, client1, myClients, password, serverStartTime, myChannels);
+        REQUIRE(client1.getNickname() == "client1N");
+        Command cmd_3(msgNick + containsComma, client1, myClients, password, serverStartTime, myChannels);
+        REQUIRE(client1.getNickname() == "client1N");
+        Command cmd_4(msgNick + containsAnAsterisk, client1, myClients, password, serverStartTime, myChannels);
+        REQUIRE(client1.getNickname() == "client1N");
+        Command cmd_5(msgNick + containsAQuestionMark, client1, myClients, password, serverStartTime, myChannels);
+        REQUIRE(client1.getNickname() == "client1N");
+        Command cmd_6(msgNick + containsAnExclamationMark, client1, myClients, password, serverStartTime, myChannels);
+        REQUIRE(client1.getNickname() == "client1N");
+        Command cmd_7(msgNick + containsAnAtSign, client1, myClients, password, serverStartTime, myChannels);
+        REQUIRE(client1.getNickname() == "client1N");
+        Command cmd_8(msgNick + containsADot, client1, myClients, password, serverStartTime, myChannels);
+        REQUIRE(client1.getNickname() == "client1N");
+        Command cmd_9(msgNick + startsWithADollar, client1, myClients, password, serverStartTime, myChannels);
+        REQUIRE(client1.getNickname() == "client1N");
+        Command cmd_10(msgNick + startsWithAColon, client1, myClients, password, serverStartTime, myChannels);
+        REQUIRE(client1.getNickname() == "client1N");
+        Command cmd_11(msgNick + startsWithAnAmpersand, client1, myClients, password, serverStartTime, myChannels);
+        REQUIRE(client1.getNickname() == "client1N");
+    }
+}
+
 TEST_CASE("Command PRIVMSG action", "[command][privmsg]") {
     int errno_before = errno;
     REQUIRE(errno == errno_before);
-    std::string serverHostname = serverHostname_g;
     time_t serverStartTime = time(NULL);
     std::string password = "password";
     struct sockaddr sockaddr;


### PR DESCRIPTION
The testCommandClass.cpp has been updated with nick test cases which consists of:
1 / Valid Nickname tests
2 / Checking error handling when attempting to set invalid nickname
3 / Checking error handling when attempting to set a nickname already in use

Potential Issues and todo:
- In order to pass error message tests, I had to use  _client.clearSendBuffer();_  for the 2 first sections, i.e. setting a valid/invalid nickname. The proper error message is returned, but shouldnt the server flush the buffer after the message has been sent? It may just be a misunderstanding on my side, in which case I would appreciate an explanation.
- TODO:  test to handle upper/lower case to be added e.g. if a client tries to set its nickname to "NICK{" when someone already has a "nick["
