### PR TITLE
Fix PART broadcast message format

### DIFF
--- a/src/command/Command.cpp
+++ b/src/command/Command.cpp
@@ -227,7 +227,8 @@ void Command::actionPart(Client& client) {
             continue;
         }
 
-        currentChannel.sendMessageToMembers(COM_MESSAGE(client.getNickname(), client.getUserName(), client.getHost(), "PART", partMessage));
+        currentChannel.sendMessageToMembers(COM_MESSAGE(client.getNickname(), client.getUserName(), client.getHost(), "PART",
+                                                        currentChannel.getName() + " :" + partMessage));
         currentChannel.partMember(client);
     }
 }


### PR DESCRIPTION
This fixes #71 
The issue was with the message that PART was sending to all the channel members including the client.
The PART message did not include the channel being parted, nor the colon before reason.