### PR TITLE
fix(invite):when a client part it needs to be invite it again

### DIFF
--- a/src/command/Command.cpp
+++ b/src/command/Command.cpp
@@ -287,6 +287,7 @@ void Command::actionPart(Client& client) {
         currentChannel.sendMessageToMembers(COM_MESSAGE(client.getNickname(), client.getUserName(), client.getHost(), "PART",
                                                         currentChannel.getName() + " :" + partMessage));
         currentChannel.partMember(client);
+        currentChannel.uninvite(client);
     }
 }
 


### PR DESCRIPTION
Now, when a client departs and the mode is set to +i, they must be re-invited every time they want to enter the channel.